### PR TITLE
ruamel_yaml import syntax change

### DIFF
--- a/dlclive/benchmark.py
+++ b/dlclive/benchmark.py
@@ -16,7 +16,7 @@ import typing
 import pickle
 import colorcet as cc
 from PIL import ImageColor
-import ruamel
+import ruamel_yaml
 
 try:
     from pip._internal.operations import freeze
@@ -351,7 +351,7 @@ def benchmark(
     if save_poses:
 
         cfg_path = os.path.normpath(f"{model_path}/pose_cfg.yaml")
-        ruamel_file = ruamel.yaml.YAML()
+        ruamel_file = ruamel_yaml.YAML()
         dlc_cfg = ruamel_file.load(open(cfg_path, "r"))
         bodyparts = dlc_cfg["all_joints_names"]
         poses = np.array(poses)

--- a/dlclive/dlclive.py
+++ b/dlclive/dlclive.py
@@ -6,7 +6,7 @@ Licensed under GNU Lesser General Public License v3.0
 """
 
 import os
-import ruamel.yaml
+import ruamel_yaml
 import glob
 import warnings
 import numpy as np
@@ -164,7 +164,7 @@ class DLCLive(object):
                 f"The pose configuration file for the exported model at {cfg_path} was not found. Please check the path to the exported model directory"
             )
 
-        ruamel_file = ruamel.yaml.YAML()
+        ruamel_file = ruamel_yaml.YAML()
         self.cfg = ruamel_file.load(open(cfg_path, "r"))
 
     @property


### PR DESCRIPTION
Resolving issue #24 with the `ruamel_yaml` package import
