### PR TITLE
tf2 update: modify tf import

### DIFF
--- a/dlclive/graph.py
+++ b/dlclive/graph.py
@@ -7,6 +7,11 @@ Licensed under GNU Lesser General Public License v3.0
 
 
 import tensorflow as tf
+vers = (tf.__version__).split('.')
+if int(vers[0])==2 or int(vers[0])==1 and int(vers[1])>12:
+    tf=tf.compat.v1
+else:
+    tf=tf
 
 
 def read_graph(file):
@@ -25,7 +30,7 @@ def read_graph(file):
     """
 
     with tf.io.gfile.GFile(file, "rb") as f:
-        graph_def = tf.compat.v1.GraphDef()
+        graph_def = tf.GraphDef()
         graph_def.ParseFromString(f.read())
         return graph_def
 
@@ -125,7 +130,7 @@ def extract_graph(graph, tf_config=None):
 
     input_tensor = get_input_tensor(graph)
     output_tensor = get_output_tensors(graph)
-    sess = tf.compat.v1.Session(graph=graph, config=tf_config)
+    sess = tf.Session(graph=graph, config=tf_config)
     inputs = graph.get_tensor_by_name(input_tensor)
     outputs = [graph.get_tensor_by_name(out) for out in output_tensor]
 

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ with open("README.md", "r") as fh:
     long_description = fh.read()
 
 install_requires = [
-    "numpy",
+    "numpy<1.19.0",
     "ruamel.yaml",
     "colorcet",
     "pillow",
@@ -31,7 +31,7 @@ if "tegra" in platform.platform():
     )
 else:
     install_requires.append("opencv-python")
-    install_requires.append("tensorflow==1.13.1")
+    install_requires.append("tensorflow")
     install_requires.append("pandas")
     install_requires.append("tables")
 


### PR DESCRIPTION
Compatibility for tf2...
- Previously, tensorflow==1.13.1 specified in setup file. This restriction has been removed.
- Changed tensorflow import in graph.py (where DeepLabCut pb files are loaded)

Important :: Whatever version of tensorflow is used to export DeepLabCut models must be used to load them in DeeplabCut-live (e.g. a network exported in tf2 will fail when trying to import in DeepLabCut-live using tf1.13, but will work if DLC-live uses tf2). I believe the same is true even for older versions of tf1 (e.g. exporting a model with tf1.8 will fail to upload in DeepLabCut-live with tf1.13). Also, networks originally created/trained in DeepLabCut using tf1 can be exported in DeepLabCut using tf2 and subsequently loaded in DeepLabCut-live w/ tf2.