### PR TITLE
Solves the bug of processing the initial frame twice

### DIFF
--- a/dlclive/dlclive.py
+++ b/dlclive/dlclive.py
@@ -265,7 +265,6 @@ class DLCLive(object):
         if frame is not None:
             if frame.ndim == 2:
                 self.convert2rgb = True
-            frame = self.process_frame(frame)
 
         # load model
 

--- a/dlclive/dlclive.py
+++ b/dlclive/dlclive.py
@@ -265,6 +265,7 @@ class DLCLive(object):
         if frame is not None:
             if frame.ndim == 2:
                 self.convert2rgb = True
+            processed_frame = self.process_frame(frame)
 
         # load model
 
@@ -292,7 +293,7 @@ class DLCLive(object):
                 model_file,
                 ["Placeholder"],
                 output_nodes,
-                input_shapes={"Placeholder": [1, frame.shape[0], frame.shape[1], 3]},
+                input_shapes={"Placeholder": [1, processed_frame.shape[0], processed_frame.shape[1], 3]},
             )
             try:
                 tflite_model = converter.convert()


### PR DESCRIPTION
Currently, when cropping and resizing parameters are given, DLCLive breaks because the initial frame is processed twice.