### PR TITLE
handle case if madlc predictions are all empty

### DIFF
--- a/dlclive/dlclive.py
+++ b/dlclive/dlclive.py
@@ -605,7 +605,11 @@ class MultiAnimalDLCLive(DLCLive):
         if self.n_animals == 1:
             pose[0] = assemblies[0].data
         else:
-            animals = np.stack([a.data for a in assemblies])
+            if len(assemblies) == 0:
+                pose[:,:,2] = 0
+                animals = np.stack(pose)
+            else:
+                animals = np.stack([a.data for a in assemblies])
             if not self.ass.identity_only:
                 if self.track_method == "box":
                     xy = trackingutils.calc_bboxes_from_keypoints(animals)


### PR DESCRIPTION
Catches the problem of stacking multi-pose predictions that are all empty; in this case it returns empty poses as it would do for the single animal case. (Solves error also in here: https://forum.image.sc/t/dlc-live-multianimal-what-is-affinity-in-inferenceutil-py-empty-assemblies-bug-or-bad-model/69972)