### PR TITLE
py-cpuinfo compatibility: renamed brand field to brand_raw

### DIFF
--- a/dlclive/benchmark.py
+++ b/dlclive/benchmark.py
@@ -130,7 +130,7 @@ def get_system_info() -> dict:
     else:
         from cpuinfo import get_cpu_info
 
-        dev = [get_cpu_info()["brand"]]
+        dev = [get_cpu_info()["brand_raw"]]
         dev_type = "CPU"
 
     return {


### PR DESCRIPTION
`brand` field in `py-cpuinfo` package was renamed to `brand_raw` on Apr 5, 2019. See this [commit](https://github.com/workhorsy/py-cpuinfo/commit/419e82e17b885f324ee3a66cbfb0cc479418987a).