### PR TITLE
Fix #112 - don't subset cpuinfo

### DIFF
--- a/dlclive/benchmark.py
+++ b/dlclive/benchmark.py
@@ -130,7 +130,7 @@ def get_system_info() -> dict:
     else:
         from cpuinfo import get_cpu_info
 
-        dev = [get_cpu_info()["brand"]]
+        dev = get_cpu_info()
         dev_type = "CPU"
 
     return {


### PR DESCRIPTION
Fix: https://github.com/DeepLabCut/DeepLabCut-live/issues/112

hi mathis(es), lab(s), and friends, miss u. about to close up shop for the day and thought i'd tick through a few low hanging fruit notifs. hope u all are doing well :)

(bug caused bc `'brand'` was replaced by `'brand_raw'` after `v5.0.0`, so it seems like why not just get the whole thing and not worry about future naming changes since it's just for diagnostics anyway)

